### PR TITLE
Changed InFilter to a pointer so that it is ommitted if empty

### DIFF
--- a/check_cisco_ucs.go
+++ b/check_cisco_ucs.go
@@ -175,7 +175,7 @@ type (
 		Cookie         string   `xml:"cookie,attr"`
 		InHierarchical string   `xml:"inHierarchical,attr"`
 		ClassId        string   `xml:"classId,attr"`
-		InFilter       InFilter
+		InFilter       *InFilter 
 	}
 
 	InFilter struct {
@@ -491,6 +491,7 @@ func main() {
 	case "class":
 		xmlConfigResolveClass := &ConfigResolveClass{Cookie: xmlAaaLoginResp.OutCookie, InHierarchical: hierarchical, ClassId: class}
 		if len(propertyFilter) > 0 {
+			xmlConfigResolveClass.InFilter = &InFilter{}
 			parts := strings.Split(propertyFilter, ":")
 			debugPrintf(3, "propertyFilter split: %#v\n", parts)
 			switch parts[0] {


### PR DESCRIPTION
Some versions of CIMC do not like an empty <InFilter /> (errors out with unexpected element).

This change simply makes the InFilter a pointer so that if it doesn't exist, an empty InFilter element will not be created.