### PR TITLE
fix num_found when mulitple expect matches

### DIFF
--- a/check_cisco_ucs.go
+++ b/check_cisco_ucs.go
@@ -591,8 +591,10 @@ func main() {
 
 	debugPrintf(3, "\n%v\n\n", r)
 	for _, val := range r {
-		n := len(re.FindAllString(val, -1))
-		num_found += n
+		matches := re.FindAllString(val, -1)
+		if len(matches) > 0 {
+		num_found++
+		}
 		debugPrintf(3, "%s num_found=%d n=%d", val, num_found, n)
 		if n == 0 && faultsOnly {
 			output += "\n" + val


### PR DESCRIPTION
with this expect string:
`-e "info|cleared|critical|major"`
and this reply from the UCS:
`cleared,Power supply 1 in chassis 5 voltage: upper-non-critical`
we were getting a double hit and a false/positive alert:
`CRIT - Cisco UCS faultInst (severity,descr) (5 of 4 ok)`
